### PR TITLE
Allow user to create instances with multiple ssh keys

### DIFF
--- a/lib/docl/cli.rb
+++ b/lib/docl/cli.rb
@@ -85,7 +85,7 @@ class DOCL::CLI < Thor
             ipv6: options.ipv6,
         }
         if options[:key]
-            call_options[:ssh_keys] = [options[:key]]
+            call_options[:ssh_keys] = options[:key].split(",")
         end
         if options.user_data
             call_options[:user_data] = File.read(options.user_data)


### PR DESCRIPTION
`docl create --key id1,id2` wil add both id1 and id2 to the created instances
